### PR TITLE
add button to open current position in lichess analysis board

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
             <div class="button-group">
                 <button id="copyFenBtn" class="button" style="background-color: #9c27b0;">Copy FEN</button>
                 <button id="copyPgnBtn" class="button" style="background-color: #9c27b0;">Copy PGN</button>
+                <button id="analyzeBtn" class="button" style="background-color: #9c27b0;">Analyze with Engine</button>
             </div>
         </div>
         <div class="fen-input">
@@ -450,6 +451,19 @@
                 alert('Failed to copy PGN to clipboard');
             }
         });
+
+        document.getElementById('analyzeBtn').addEventListener('click', async () => {
+            try {
+                const fen = await game.fen();
+                const encodedFen = encodeURIComponent(fen);
+                const url = `https://lichess.org/analysis/standard/${encodedFen}`;
+                window.open(url, '_blank');
+            } catch (error) {
+                console.error('Error opening analysis board:', error);
+                alert('Failed to open lichess analysis board');
+            }
+        });
+
 
         document.getElementById('setFenBtn').addEventListener('click', () => {
             const fenInput = document.getElementById('fenInput');


### PR DESCRIPTION
Allows you to open the current position on a lichess analysis board in a new tab if you click `Analyze with Engine`

<img width="1046" alt="Screenshot 2025-02-04 at 1 13 57 PM" src="https://github.com/user-attachments/assets/cb90fe77-d79e-4eda-a237-60ea5da9d9c5" />
<img width="1269" alt="Screenshot 2025-02-04 at 1 14 15 PM" src="https://github.com/user-attachments/assets/5e3bf365-1dba-4f48-b3e7-bf649b4a5d3d" />
