### PR TITLE
Add undo/redo move buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,9 @@
         let playerColor = 'white';
         let movesDiv = document.getElementById('moves');
         let cg = null;
+        let appliedMoves = [];
+        let undoneMoves = [];
+
 
         // Utility functions for Chessground
         function toDests(chess) {
@@ -251,6 +254,8 @@
             });
 
             if (move) {
+                appliedMoves.push(move);
+                undoneMoves = []; // Clear redo stack on a new move
                 updateBoard();
                 updateMovesList();
 
@@ -495,7 +500,7 @@
                 document.getElementById('status').className = 'warning';
             }
         });
-        
+
         document.getElementById('backBtn').addEventListener('click', () => {
           if (appliedMoves.length > 0) {
             // Undo the last move and push it onto the redo stack

--- a/index.html
+++ b/index.html
@@ -142,7 +142,15 @@
         <div id="status" class="info">Set up your starting position. You can play moves for both sides. Then click "Start Practice".</div>
         <div class="board-and-moves">
             <div id="board" class="board"></div>
-            <div id="moves" class="moves-list"></div>
+            <div class="moves-list" id="movesContainer">
+              <div id="moveNavigation" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                <button id="backBtn" class="button" title="Undo Move">&#8592;</button>
+                <span>Moves Played</span>
+                <button id="forwardBtn" class="button" title="Redo Move">&#8594;</button>
+              </div>
+              <div id="moves"></div>
+            </div>
+
         </div>
         <div class="controls">
             <button id="startBtn" class="button">Start Practice</button>
@@ -487,6 +495,35 @@
                 document.getElementById('status').className = 'warning';
             }
         });
+        
+        document.getElementById('backBtn').addEventListener('click', () => {
+          if (appliedMoves.length > 0) {
+            // Undo the last move and push it onto the redo stack
+            const move = game.undo();
+            undoneMoves.push(move);
+            appliedMoves.pop();
+            updateBoard();
+            updateMovesList();
+          }
+        });
+
+        document.getElementById('forwardBtn').addEventListener('click', () => {
+          if (undoneMoves.length > 0) {
+            // Reapply the move details stored in undoneMoves
+            const move = undoneMoves.pop();
+            const result = game.move({
+              from: move.from,
+              to: move.to,
+              promotion: move.promotion || 'q'
+            });
+            if (result) {
+              appliedMoves.push(result);
+              updateBoard();
+              updateMovesList();
+            }
+          }
+        });
+
 
         // Initialize everything
         window.addEventListener('load', () => {


### PR DESCRIPTION
Adds back and forward arrows to the move list in order to undo and redo moves. Useful for:

* going back to your starting position to practice again (e.g. below black goes back after 5. Bg5, hits `Start Practice` again, and white plays a different fifth move)
*  undoing a move and starting from there again if you accidentally played the wrong move
* Going back and grabbing PGN/fen from a position you encountered during the practice 

Also confirmed that as before, current board state opens in the lichess analysis window after undoing/redoing moves.

<img width="1022" alt="Screenshot 2025-02-06 at 2 49 17 PM" src="https://github.com/user-attachments/assets/9a874da2-ff97-4e35-8151-dd557abcfb1a" />
<img width="1016" alt="Screenshot 2025-02-06 at 2 50 21 PM" src="https://github.com/user-attachments/assets/155141c1-3144-429e-9fca-c6a364d2ef9f" />

A future improvement would be to show the full move list when you undo moves, with the undone moves grayed out and the current move highlighted
