### PR TITLE
analyze with engine now opens full PGN analysis board

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,17 +465,23 @@
             }
         });
 
-        document.getElementById('analyzeBtn').addEventListener('click', async () => {
-            try {
-                const fen = await game.fen();
-                const encodedFen = encodeURIComponent(fen);
-                const url = `https://lichess.org/analysis/standard/${encodedFen}`;
-                window.open(url, '_blank');
-            } catch (error) {
-                console.error('Error opening analysis board:', error);
-                alert('Failed to open lichess analysis board');
+        document.getElementById('analyzeBtn').addEventListener('click', () => {
+          try {
+            const moves = game.history(); // e.g. ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "Bxf7+"]
+            if (!moves.length) {
+              alert('No moves played yet.');
+              return;
             }
+            // Join moves with underscores to form the PGN part of the URL.
+            const pgnMoves = moves.join('_');
+            const url = `https://lichess.org/analysis/pgn/${encodeURIComponent(pgnMoves)}`;
+            window.open(url, '_blank');
+          } catch (error) {
+            console.error('Error generating PGN:', error);
+            alert('Failed to generate PGN for analysis.');
+          }
         });
+
 
 
         document.getElementById('setFenBtn').addEventListener('click', () => {


### PR DESCRIPTION
The lichess API [allows](https://lichess.org/api#tag/Games/operation/gameImport) you to embed PGN moves into the URL to open a board with that PGN. 

This PR updates the `Analyze with Engine` button to open a full PGN rather than just the FEN of the final position. I also verified that with the `+` symbol from a check and `#` symbol from mate, it still works

<img width="1008" alt="Screenshot 2025-02-09 at 8 42 07 PM" src="https://github.com/user-attachments/assets/ff792c9c-ca4b-4b64-97da-1b5c35166167" />
<img width="1412" alt="Screenshot 2025-02-09 at 8 42 59 PM" src="https://github.com/user-attachments/assets/81c61f97-5422-4907-8398-2853b791da77" />
_note the URL_
