### PR TITLE
fix unreadable text in dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -361,7 +361,13 @@ h1 {
         color: #fff;
     }
 
-    .moves-list, .filters, .repertoire-checker {
+    #status {
+        background-color: #2a4b7c; /* Darker blue for contrast */
+        color: #fff; /* White text for readability */
+        border-left: 4px solid #2196F3; /* Keep the blue accent */
+    }
+
+    .moves-list, .filters, .repertoire-checker, .saved-positions {
         background: #2d2d2d;
     }
 
@@ -377,7 +383,7 @@ h1 {
         color: #fff;
     }
 
-    h1 {
+    h1, .saved-positions h3, #status {
         color: #fff;
     }
 
@@ -385,7 +391,7 @@ h1 {
         background: #333;
         border-color: #444;
     }
-    
+
     .position-item:hover {
         background: #404040;
     }
@@ -399,4 +405,4 @@ h1 {
     #moveNavigation {
         background: #333;
     }
-} 
+}


### PR DESCRIPTION
Fixes unreadable text for dark mode users (ironically, the most enlightened of users)

<img width="1209" alt="Screenshot 2025-02-24 at 8 02 09 PM" src="https://github.com/user-attachments/assets/6f2f49f2-ae26-49e7-9d2a-658a11f04b7c" />

_before status text_

<img width="1227" alt="Screenshot 2025-02-24 at 8 01 44 PM" src="https://github.com/user-attachments/assets/65972a99-1a2f-4fb6-9306-605ad1489a9a" />

_after status text_

<img width="1203" alt="Screenshot 2025-02-24 at 8 04 57 PM" src="https://github.com/user-attachments/assets/f043e2d8-7865-4c47-9960-4ec55ed67181" />

_before saved positions text_

<img width="1229" alt="Screenshot 2025-02-24 at 8 05 51 PM" src="https://github.com/user-attachments/assets/fa6907c7-4b3f-4f44-a02d-2a935db30808" />

_after saved positions text_


closes #14 

